### PR TITLE
Add secrets.json

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,15 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+    ],
+    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
 load("//lib:secrets.bzl","environment_secrets")
 
 ####
@@ -8,5 +20,6 @@ environment_secrets(
     entries = {
         "MAVEN_USER": "<REQUIRED>",
         "MAVEN_PASS": "<REQUIRED>",
+        "DEFAULT": "some_default_value",
     },
 )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -9,3 +9,9 @@ genrule(
     #cmd = "echo OK > \"$@\"",
     cmd = "echo 'MAVEN_USER={0} MAVEN_PASS={1}'> \"$@\"".format(MAVEN_USER,MAVEN_PASS),
 )
+
+py_test(
+    name = "secret_file_test",
+    srcs = ["secret_file_test.py"],
+    data = ["@env//:secrets"],
+)

--- a/examples/secret_file_test.py
+++ b/examples/secret_file_test.py
@@ -1,0 +1,27 @@
+import json
+
+
+def get_bzl_secrets():
+    with open("../env/secrets.bzl") as file:
+        return {
+            # Remove the leading `"` and trailing `"\n`.
+            key: value[1:-2]
+            for (key, value) in (
+                line.split("=", 1)
+                for line in file
+                if not line.startswith("#")
+            )
+        }
+
+
+def get_json_secrets():
+    with open("../env/secrets.json") as file:
+        return json.load(file)
+
+
+if __name__ == "__main__":
+    bzl_secrets = get_bzl_secrets()
+    json_secrets = get_json_secrets()
+
+    assert set(bzl_secrets.keys()) == {"DEFAULT", "MAVEN_USER", "MAVEN_PASS"}
+    assert json_secrets == bzl_secrets

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -1,9 +1,6 @@
-load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-skylark_library(
+bzl_library(
     name = "secrets",
     srcs = ["secrets.bzl"],
-    deps = [
-        "//skylib:label",
-    ],
 )


### PR DESCRIPTION
This augments the `environment_secrets` repository rule to also emit
`secrets.json` alongside `secrets.bzl`. This allows application code to
parse the JSON file rather than the skylark file to retrieve all
secrets. Alternatively, the user could list the secrets in
`environment_secrets`, duplicate them in the `load()` statement, and
duplicate them in some sort of template expansion genrule to create a
file to be used at runtime.

NOTE: This also adds the latest version of skylib because it wasn't
available otherwise.