### PR TITLE
Expand documentation for WORKSPACE changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ be used as the default.
 WORKSPACE:
 
 ```python 
+    load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+    git_repository(
+        name = "com_github_solarhess_rules_build_secrets",
+        remote = "http://github.com/solarhess/rules_build_secrets",
+        commit = "103b222eba64355b93649b06ecfe3844466b5a65",  # update as necessary
+    )
+
+    load("@com_github_solarhess_rules_build_secrets//lib:secrets.bzl", "environment_secrets")
+
     environment_secrets(
         name="env", 
         entries = {


### PR DESCRIPTION
Add the full set of directives that need to be added to WORKSPACE in order to use environment_secrets. This seems to be the approach preferred in Bazel-land (see rules_docker for an example), and makes life easier on users of this code.